### PR TITLE
Update mocks: search database_services by account

### DIFF
--- a/lib/ey-core/requests/get_database_services.rb
+++ b/lib/ey-core/requests/get_database_services.rb
@@ -22,6 +22,12 @@ class Ey::Core::Client
         params["provider"] = url_for("/providers/#{provider_id}")
       end
 
+      if account_id = resource_identity(params.delete("account"))
+        if provider = self.data[:providers].values.detect{|p| p["account"].index(account_id)}
+          params["provider"] = url_for("/providers/#{provider["id"]}")
+        end
+      end
+
       resources = if environment_id = resource_identity(params.delete("environment") || params.delete("environment_id"))
                     self.data[:connectors].
                       select { |_,c| c["_environment"] == url_for("/environments/#{environment_id}") }.

--- a/spec/database_services_spec.rb
+++ b/spec/database_services_spec.rb
@@ -111,5 +111,11 @@ describe "database services" do
 
       expect(client.get_environment_database_services(environment_id: environment.id).body["database_services"].first["id"]).to eq(environment_database_service.id)
     end
+
+    it 'should list database services in an account' do
+      environment_database_service, environment = load_blueprint
+
+      expect(client.database_services.all(account: environment.account.id).map(&:id)).to include(environment_database_service.id)
+    end
   end
 end

--- a/spec/support/resource_helper.rb
+++ b/spec/support/resource_helper.rb
@@ -1,6 +1,6 @@
 module ResourceHelper
   def load_blueprint(options={})
-    logical_database = create_logical_database(client: options[:client])
+    logical_database = create_logical_database(client: options[:client], provider: account.providers.first)
 
     application = account.applications.create!(name: "application#{SecureRandom.hex(4)}", repository: "git://github.com/engineyard/todo.git", type: "rails3")
     environment = account.environments.create!(name: "environment#{SecureRandom.hex(4)}")
@@ -82,7 +82,7 @@ module ResourceHelper
   end
 
   def create_database_service(options={})
-    provider = options.fetch(:provider) { create_provider(options.merge(client: client)) }
+    provider = options[:provider] || create_provider(options.merge(client: client))
 
     database_service_params = Hashie::Mash.new(
       :name     => Faker::Name.first_name,


### PR DESCRIPTION
It works against production, so it should work in mocked mode (broker
wants to write tests)
Service Brokers are to be attached at the account level (not provider
level), therefore a catalog request to service broker will need to fetch
a list of all running RDS services available on the account.
