### PR TITLE
Delete share_ey_sso_backend mock hooks

### DIFF
--- a/lib/ey-core/client.rb
+++ b/lib/ey-core/client.rb
@@ -510,18 +510,6 @@ class Ey::Core::Client < Cistern::Service
     include Ey::Core::Mock::Helper
     extend Ey::Core::Mock::Util
 
-    def self.share_ey_sso_backend!
-      @share_ey_sso_backend = true
-    end
-
-    def self.share_ey_sso_backend?
-      @share_ey_sso_backend
-    end
-
-    def share_ey_sso_backend?
-      self.class.share_ey_sso_backend?
-    end
-
     def self.for(type, options={})
       case type
       when :server

--- a/lib/ey-core/mock/resources.rb
+++ b/lib/ey-core/mock/resources.rb
@@ -39,23 +39,6 @@ module Ey::Core::Mock
     def find(collection, id_or_url)
       id = resource_identity(id_or_url)
 
-      if share_ey_sso_backend? && id
-        case collection
-        when :accounts then
-          if sso_account = EY::SSO::Account.get(id)
-            self.data[:accounts][id] ||= mock_account_setup(sso_account.id, :name => sso_account.name)
-          end
-        when :users
-          if sso_user = EY::SSO::User.get(id)
-            self.data[:users][id] ||= {
-              "id"       => id,
-              "email"    => sso_user.email,
-              "accounts" => url_for("/users/#{id}/accounts"),
-            }
-          end
-        end
-      end
-
       # polymorphic associations suck
       if collection.is_a?(Array)
         resource = collection.map do |key|

--- a/lib/ey-core/requests/get_accounts.rb
+++ b/lib/ey-core/requests/get_accounts.rb
@@ -20,18 +20,6 @@ class Ey::Core::Client
                   user_url.split('/').last
                 end
 
-      if share_ey_sso_backend? && user_id
-        if sso_user = EY::SSO::User.get(user_id)
-          if sso_user.accounts.exists?
-            sso_user.accounts.each do |sso_account|
-              self.data[:accounts][sso_account.id] ||= mock_account_setup(sso_account.id, :name => sso_account.name)
-              self.data[:accounts][sso_account.id][:account_users] ||= []
-              self.data[:accounts][sso_account.id][:account_users] << user_id
-            end
-          end
-        end
-      end
-
       resources = if user_id
                     find(:users, user_id)
                     self.data[:accounts].select{|k,v| v[:account_users] && v[:account_users].include?(user_id)}


### PR DESCRIPTION
The apps that used this are now fully ported to core (no longer interact
directly with SSO)
