### PR TITLE
Mock.delay to control how quickly requests finish

### DIFF
--- a/lib/ey-core/client.rb
+++ b/lib/ey-core/client.rb
@@ -667,9 +667,18 @@ class Ey::Core::Client < Cistern::Service
       end
     end
 
+    class << self
+      attr_accessor :delay
+    end
+
     def self.reset!
       @data = nil
       @serial_id = 1
+      @delay = 1
+    end
+
+    def delay
+      self.class.delay
     end
 
     def data

--- a/lib/ey-core/requests/get_request.rb
+++ b/lib/ey-core/requests/get_request.rb
@@ -18,27 +18,35 @@ class Ey::Core::Client
       request = self.find(:requests, id)
       request["callback_url"] = "#{self.url}/requests/#{id}/callback"
 
-      response_hash = if request["finished_at"].nil? # finish a previously unfinished request
-                        resource_key, key, resource, resource_url = request.delete("resource")
+      request["poll_count"] ||= 0
+      request["poll_count"] += 1
 
-                        if resource # provisioning
-                          if resource.is_a?(Array)
-                            resource.each { |res| self.data[resource_key][res["id"]] = res }
+      response_hash = if request["finished_at"].nil?
+                        if request["poll_count"] >= delay
+                          # finish a previously unfinished request
+                          resource_key, key, resource, resource_url = request.delete("resource")
+
+                          if resource # provisioning
+                            if resource.is_a?(Array)
+                              resource.each { |res| self.data[resource_key][res["id"]] = res }
+                            else
+                              resource_url ||= if resource.respond_to?(:call)
+                                                 resource.call(request)
+                                               else
+                                                 self.data[resource_key][key] = resource
+                                                 resource.delete("resource_url")
+                                               end
+                            end
+                            request["finished_at"] = Time.now
+                            request["resource"] = resource_url
                           else
-                            resource_url ||= if resource.respond_to?(:call)
-                                               resource.call(request)
-                                             else
-                                               self.data[resource_key][key] = resource
-                                               resource.delete("resource_url")
-                                             end
+                            resource = self.data[resource_key].delete(key) # deprovisioning
+                            self.data[:deleted][resource_key][key] ||= resource
                           end
-                          request["finished_at"] = Time.now
-                          request["resource"] = resource_url
+                          request
                         else
-                          resource = self.data[resource_key].delete(key) # deprovisioning
-                          self.data[:deleted][resource_key][key] ||= resource
+                          request
                         end
-                        request
                       elsif request["finished_at"] # already finished
                         request
                       else
@@ -50,6 +58,9 @@ class Ey::Core::Client
                           end
                         end
                       end
+
+      response_hash = response_hash.dup
+      response_hash.delete("poll_count")
 
       response(
         :body   => {"request" => response_hash},

--- a/spec/requests_spec.rb
+++ b/spec/requests_spec.rb
@@ -19,5 +19,13 @@ RSpec.describe Ey::Core::Client do
     it "should list unfinished requests" do
       expect(client.requests.all(finished_at: nil)).to contain_exactly(request)
     end
+
+    it "request should finish after polling a number of times == Mock.delay" do
+      Ey::Core::Client::Mock.delay = 3
+      expect(client.requests.get(request.id).finished_at).to be_nil
+      expect(client.requests.get(request.id).finished_at).to be_nil
+      expect(client.requests.get(request.id).finished_at).to_not be_nil
+    end
+
   end
 end


### PR DESCRIPTION
A corrolary to Fog::Mock.delay

Default value of 1 means request will finish on the 1st poll.

0 could mean the request finishes before even polling, but that's not
implemented yet (and not necessarily needed either)
