### PR TITLE
Change request hash to symbols

### DIFF
--- a/lib/ey-core/requests/get_costs.rb
+++ b/lib/ey-core/requests/get_costs.rb
@@ -2,8 +2,8 @@ class Ey::Core::Client
   class Real
     def get_costs(params={})
       request(
-        "url"  => params["url"],
-        "path" => "/accounts/#{params["id"]}/costs"
+        :url  => params["url"],
+        :path => "/accounts/#{params["id"]}/costs"
       )
     end
   end


### PR DESCRIPTION
Apparently the request method actually needs symbols and not quoted strings in the hash. I'm dumb
