### PR TITLE
Add endpoint for creating new password

### DIFF
--- a/lib/ey-core/client.rb
+++ b/lib/ey-core/client.rb
@@ -157,6 +157,7 @@ class Ey::Core::Client < Cistern::Service
   request :create_logical_database
   request :create_membership
   request :create_message
+  request :create_password_reset
   request :create_provider
   request :create_slots
   request :create_ssl_certificate

--- a/lib/ey-core/requests/create_password_reset.rb
+++ b/lib/ey-core/requests/create_password_reset.rb
@@ -1,0 +1,38 @@
+class Ey::Core::Client
+  class Real
+    def create_password_reset(params)
+      request(
+        :method => :post,
+        :path   => "/password-resets",
+        :body   => {
+          :password_reset => params
+        }
+      )
+    end
+  end # Real
+
+  class Mock
+    def create_password_reset(_params)
+      params = Cistern::Hash.stringify_keys(_params)
+
+      unless self.data[:users].map{ |_, user| user["email"] }.include?(params["email"])
+        response(
+          :body => {
+            :errors => ["Could not find User with email \"#{params["email"]}\""]
+          },
+          :status => 404
+        )
+      end
+
+      response(
+        :body => {
+          "password_reset" => {
+            "sent" => true
+          },
+        },
+        :status  => 201,
+      )
+    end
+  end # Mock
+end # Ey::Core::Client
+

--- a/lib/ey-core/requests/reset_password.rb
+++ b/lib/ey-core/requests/reset_password.rb
@@ -4,30 +4,23 @@ class Ey::Core::Client
       params = Cistern::Hash.stringify_keys(_params)
 
       request(
-        :method => :post,
-        :path   => "/password-resets",
-        :body   => params,
+        :method => :put,
+        :path   => "/password-resets/#{params["reset_token"]}",
+        :body   => {
+          :password_reset => {
+            :password => params["password"]
+          }
+        },
       )
     end
   end # Real
 
   class Mock
-    def reset_password(_params)
-      params = Cistern::Hash.stringify_keys(_params)
-
-      unless self.data[:users].map{ |_, user| user["email"] }.include?(params["email"])
-        response(
-          :body => {
-            :errors => ["Could not find User with email \"#{params["email"]}\""]
-          },
-          :status => 404
-        )
-      end
-
+    def reset_password(*)
       response(
         :body => {
           "password_reset" => {
-            "sent" => true
+            "accepted" => true
           },
         },
         :status  => 201,

--- a/spec/reset_password_spec.rb
+++ b/spec/reset_password_spec.rb
@@ -1,15 +1,21 @@
 require 'spec_helper'
 
-describe 'reset_password' do
+describe "reset_password" do
   context "with an HMAC client" do
     let!(:client) { create_hmac_client }
 
     it "should create a password reset request" do
       email = create_user.email
 
-      password_reset = client.reset_password(email: email, redirect_uri: "http://example.com").body["password_reset"]
+      password_reset = client.create_password_reset(email: email, redirect_uri: "http://example.com").body["password_reset"]
 
       expect(password_reset).to eq("sent" => true)
+    end
+
+    it "should reset a users password", :mock_only do
+      password_reset = client.reset_password(reset_token: SecureRandom.hex(6), password: SecureRandom.hex(6)).body["password_reset"]
+
+      expect(password_reset).to eq("accepted" => true)
     end
   end
 end


### PR DESCRIPTION
`create_password_reset` kicks off the process
`reset_password` takes the new password from the user and the generated
token from `create_password_reset`
