### PR TITLE
[ENG-193] Create untracked addresses via smithy

### DIFF
--- a/lib/ey-core/client.rb
+++ b/lib/ey-core/client.rb
@@ -60,6 +60,7 @@ class Ey::Core::Client < Cistern::Service
   collection :storages
   collection :tasks
   collection :tokens
+  collection :untracked_addresses
   collection :untracked_servers
   collection :users
   collection :volumes
@@ -124,6 +125,7 @@ class Ey::Core::Client < Cistern::Service
   model :support_trial
   model :task
   model :token
+  model :untracked_address
   model :untracked_server
   model :user
   model :volume
@@ -165,6 +167,7 @@ class Ey::Core::Client < Cistern::Service
   request :create_storage_user
   request :create_task
   request :create_token
+  request :create_untracked_address
   request :create_untracked_server
   request :create_user
   request :destroy_addon
@@ -312,6 +315,7 @@ class Ey::Core::Client < Cistern::Service
   request :run_cluster_component_action
   request :run_environment_application_action
   request :signup
+  request :update_address
   request :update_addon
   request :update_addon_attachment
   request :update_alert

--- a/lib/ey-core/collections/untracked_addresses.rb
+++ b/lib/ey-core/collections/untracked_addresses.rb
@@ -1,0 +1,4 @@
+class Ey::Core::Client::UntrackedAddresses < Ey::Core::Collection
+  model Ey::Core::Client::UntrackedAddress
+  self.model_root         = "untracked_address"
+end

--- a/lib/ey-core/models/address.rb
+++ b/lib/ey-core/models/address.rb
@@ -7,6 +7,7 @@ class Ey::Core::Client::Address < Ey::Core::Model
   attribute :ip_address
   attribute :provisioned_id
   attribute :location
+  attribute :disappeared_at, type: :time
 
   has_one :provider
   has_one :server
@@ -35,12 +36,23 @@ class Ey::Core::Client::Address < Ey::Core::Model
       params = {
         "provider" => self.provider_id,
         "address"  => {
-          "location" => self.location,
+          "location"       => self.location,
+          "provisioned_id" => self.provisioned_id
         },
       }
 
       self.connection.requests.new(self.connection.create_address(params).body["request"])
-    else raise NotImplementedError
+    else
+      requires :identity
+
+      params = {
+        "id" => self.identity,
+        "address" => {
+          "disappeared_at" => self.disappeared_at,
+        }
+      }
+
+      merge_attributes(self.connection.update_address(params).body["address"])
     end
   end
 end

--- a/lib/ey-core/models/untracked_address.rb
+++ b/lib/ey-core/models/untracked_address.rb
@@ -1,0 +1,24 @@
+class Ey::Core::Client::UntrackedAddress < Ey::Core::Model
+  extend Ey::Core::Associations
+
+  attribute :provisioned_id
+  attribute :provisioner_id
+  attribute :location
+
+  has_one :provider
+  has_one :address
+
+  def save!
+    request_attributes = {
+      "provider" => self.provider_id,
+      "url"      => self.collection.url,
+      "address"  => {
+        "location" => self.location,
+        "provisioned_id" => self.provisioned_id,
+        "provisioner_id" => self.provisioner_id,
+      }
+    }
+
+    merge_attributes(connection.create_untracked_address(request_attributes).body["untracked_address"])
+  end
+end

--- a/lib/ey-core/requests/create_address.rb
+++ b/lib/ey-core/requests/create_address.rb
@@ -18,7 +18,7 @@ class Ey::Core::Client
       self.find(:providers, provider_id)
 
       resource = params["address"].dup
-      ip_address = self.ip_address
+      ip_address = resource["provisioned_id"] || self.ip_address
       resource.merge!(
         "id"             => resource_id,
         "provisioned_id" => ip_address,

--- a/lib/ey-core/requests/create_untracked_address.rb
+++ b/lib/ey-core/requests/create_untracked_address.rb
@@ -1,0 +1,48 @@
+class Ey::Core::Client
+  class Real
+    def create_untracked_address(params={})
+      request(
+        :body   => params,
+        :method => :post,
+        :path   => "/untracked-addresses",
+        :url    => params.delete("url"),
+      )
+    end
+  end # Real
+
+  class Mock
+    def create_untracked_address(params={})
+      url         = params["url"]
+
+      provider_id ||= params["provider"] || (url && path_params(url)["providers"])
+      find(:providers, provider_id)
+
+      resource = params["address"].dup
+
+      require_parameters(resource, "location", "provisioned_id", "provisioner_id")
+      existing_address = self.data[:addresses].find {|id, a| a['provisioned_id'] == resource["provisioned_id"] }
+
+      if existing_address
+        existing_id, existing_address = existing_address
+        response(
+          :body => {"errors" => ["Address '#{resource['provisioned_id']}' is tracked."],
+                    "address" => url_for("/addresses/#{existing_id}")},
+          :status => 409,
+        )
+      else
+        tracked_address = self.addresses.create!(resource.merge("provider" => provider_id)).resource!
+
+        resource.merge!(
+          "provider" => url_for("/providers/#{provider_id}"),
+          "location" => resource['location'],
+          "address" => url_for("/addresses/#{tracked_address.id}"),
+        )
+
+        response(
+          :body   => { "untracked_address" => resource },
+          :status => 201,
+        )
+      end
+    end
+  end # Mock
+end # Ey::Core::Client

--- a/lib/ey-core/requests/get_addresses.rb
+++ b/lib/ey-core/requests/get_addresses.rb
@@ -16,7 +16,7 @@ class Ey::Core::Client
     def get_addresses(params={})
       extract_url_params!(params)
 
-      headers, addresses_page = search_and_page(params, :addresses, search_keys: %w[provisioned_id ip_address server location])
+      headers, addresses_page = search_and_page(params, :addresses, search_keys: %w[provisioned_id ip_address server location provider])
 
       response(
         :body    => {"addresses" => addresses_page},

--- a/lib/ey-core/requests/update_address.rb
+++ b/lib/ey-core/requests/update_address.rb
@@ -1,0 +1,29 @@
+class Ey::Core::Client
+  class Real
+    def update_address(params={})
+      id = params["id"]
+
+      request(
+        :method => :put,
+        :path   => "addresses/#{id}",
+        :body   => {"address" => params.fetch("address")}
+      )
+    end
+  end # Real
+
+  class Mock
+    def update_address(params={})
+      identity = resource_identity(params)
+      address  = find(:addresses, identity)
+
+      address_params = Cistern::Hash.slice(Cistern::Hash.stringify_keys(params["address"]), "disappeared_at")
+
+      address.merge! address_params
+
+      response(
+        :body => { "address" => address },
+        :status => 200
+      )
+    end
+  end # Mock
+end # Ey::Core::Client


### PR DESCRIPTION
Add requests for creating untracked addresses and for updating disappeared addresses

As a side note, I'd like to see these methods (and the `untracked_server` requests/models/collections) moved out of this. I don't think we should be polluting this library with our internal house keeping tasks. 

As it stands at the moment, Smithy struggles with using the private core extension due to the setting for using the private Accept header being global, and it using multiple instances of core clients. We'd need to resolve that first.
# ENG-193
