### PR TITLE
Support chef upgrade environments and see chef log

### DIFF
--- a/lib/ey-core/cli.rb
+++ b/lib/ey-core/cli.rb
@@ -45,6 +45,10 @@ class Ey::Core::Cli
         options[:logger] = v ? Logger.new(STDOUT) : Logger.new(nil)
       end
 
+      opts.on("-e", "--execute-command [COMMAND]", "Execute Command") do |c|
+        @execute_command = c
+      end
+
       opts.separator ""
       opts.separator "Common options:"
 
@@ -74,8 +78,12 @@ class Ey::Core::Cli
   end
 
   def console
-    Pry.config.prompt = proc { |obj, nest_level, _| "ey-core:> " }
-    self.pry
+    if @execute_command
+      @client.instance_eval(@execute_command)
+    else
+      Pry.config.prompt = proc { |obj, nest_level, _| "ey-core:> " }
+      @client.pry
+    end
   end
 
   def show

--- a/lib/ey-core/client.rb
+++ b/lib/ey-core/client.rb
@@ -292,6 +292,7 @@ class Ey::Core::Client < Cistern::Service
   request :update_application_archive
   request :update_billing
   request :update_blueprint
+  request :update_environment
   request :update_membership
   request :update_server
   request :update_ssl_certificate
@@ -334,7 +335,7 @@ class Ey::Core::Client < Cistern::Service
 
       unless @authentication == :none
         if !@auth_id && !@auth_key && !@token
-          raise "Missing token. Use Ey::Core::Client.new(token: mytoken) or add \"'#{@url}': mytoken\" to your ~/.ey-core file" unless @token
+          raise "Missing token. Use Ey::Core::Client.new(token: mytoken) or add \"'#{@url}': mytoken\" to your ~/.ey-core file (see: https://cloud.engineyard.com/cli)" unless @token
         elsif options[:token] || (@token && !@auth_id) # token was explicitly provided
           @authentication = :token
         else

--- a/lib/ey-core/models/log.rb
+++ b/lib/ey-core/models/log.rb
@@ -3,6 +3,7 @@ class Ey::Core::Client::Log < Ey::Core::Model
 
   identity :id
 
+  attribute :created_at
   attribute :filename
   attribute :mime_type
   attribute :download_url
@@ -30,4 +31,14 @@ class Ey::Core::Client::Log < Ey::Core::Model
 
     merge_attributes(self.connection.create_log(params).body["log"])
   end
+
+  def contents
+    body = Faraday.get(download_url).body
+    if filename.match(/\.gz$/)
+      Zlib::GzipReader.new(StringIO.new(body, "rb")).read
+    else
+      body
+    end
+  end
+
 end

--- a/lib/ey-core/models/request.rb
+++ b/lib/ey-core/models/request.rb
@@ -21,9 +21,14 @@ class Ey::Core::Client::Request < Ey::Core::Model
     merge_attributes(connection.request_callback("url" => self.callback_url).body["request"])
   end
 
-  def ready!(timeout = self.service.timeout, interval = self.service.poll_interval)
-    wait_for!(timeout, interval) { ready? }
-    raise Ey::Core::RequestFailure.new(self) unless successful?
+  def ready!(timeout = self.service.timeout, interval = self.service.poll_interval, raise_on_failure = true, &block)
+    wait_for!(timeout, interval) do
+      yield self if block_given?
+      ready?
+    end
+    if raise_on_failure && !successful?
+      raise Ey::Core::RequestFailure.new(self)
+    end
     self
   end
 

--- a/lib/ey-core/models/server.rb
+++ b/lib/ey-core/models/server.rb
@@ -33,6 +33,7 @@ class Ey::Core::Client::Server < Ey::Core::Model
   has_many :volumes
   has_many :events, key: :server_events
   has_many :firewalls
+  has_many :logs
 
   attr_accessor :mnt_volume_size, :volume_size, :iops, :snapshot_id
 
@@ -40,6 +41,14 @@ class Ey::Core::Client::Server < Ey::Core::Model
     requires :identity
 
     connection.requests.new(self.connection.apply_server_updates("id" => self.identity, "type" => type).body["request"])
+  end
+
+  def latest_main_log
+    logs.select{|l| l.filename.match(/main/)}.sort_by(&:created_at).last
+  end
+
+  def latest_custom_log
+    logs.select{|l| l.filename.match(/custom/)}.sort_by(&:created_at).last
   end
 
   def reboot

--- a/lib/ey-core/requests/update_environment.rb
+++ b/lib/ey-core/requests/update_environment.rb
@@ -1,0 +1,17 @@
+class Ey::Core::Client
+  class Real
+    def update_environment(params={})
+      request(
+        :method => :put,
+        :path   => "/environments/#{params.fetch("id")}",
+        :body   => {"environment" => params.fetch("environment")},
+      )
+    end
+  end
+
+  class Mock
+    def update_environment(params={})
+      raise NotImplementedError
+    end
+  end
+end


### PR DESCRIPTION
Allow a -e option to ey-core console command (akin to ruby -e)

Support updating environment (name and release label)

Allow fetching logs on `server` (chef logs)

Helpers to fetch latest main and latest custom chef logs

helpers to see gz chef logs as plaintext

Example `ey-core` command utilizing additions in this commit:

    bundle exec ey-core console -e 'e = environments.first(name: "jacobstackdev")
      e.update(release_label: "latest")
      e.apply("main", retry_limit: 0).ready!(600,10,false){|r| puts "Waiting for apply, current stage: #{r.stage}"}
      puts e.servers.first.latest_main_log.contents'