### PR TITLE
Converted Cli to a namespace

### DIFF
--- a/bin/ey-core
+++ b/bin/ey-core
@@ -1,4 +1,4 @@
 #!/usr/bin/env ruby
-require File.expand_path('../../lib/ey-core/cli', __FILE__)
+require File.expand_path('../../lib/ey-core/cli/main', __FILE__)
 
-Ey::Core::Cli.new(ARGV).execute!
+Ey::Core::Cli::Main.new(ARGV).execute!

--- a/lib/ey-core/cli.rb
+++ b/lib/ey-core/cli.rb
@@ -1,24 +1,8 @@
-require 'optparse'
-require 'ostruct'
-require 'ey-core'
-require 'awesome_print'
-require 'pry'
-require 'belafonte'
-require 'table_print'
-require 'rubygems/package'
-require 'escape'
+module Ey
+  module Core
 
-Cistern.formatter = Cistern::Formatter::AwesomePrint
-
-
-class Ey::Core::Cli < Belafonte::App
-  title "Engineyard CLI"
-  summary "Successor to the engineyard gem"
-
-  require_relative "cli/subcommand"
-  Dir[File.dirname(__FILE__) + '/cli/*.rb'].each {|file| load file }
-
-  Ey::Core::Cli::Subcommand.descendants.each do |d|
-    mount d
+    # The overall namespace for CLI-related code
+    module Cli
+    end
   end
 end

--- a/lib/ey-core/cli/main.rb
+++ b/lib/ey-core/cli/main.rb
@@ -1,0 +1,27 @@
+require 'optparse'
+require 'ostruct'
+require 'ey-core'
+require 'ey-core/cli'
+require 'awesome_print'
+require 'pry'
+require 'belafonte'
+require 'table_print'
+require 'rubygems/package'
+require 'escape'
+
+Cistern.formatter = Cistern::Formatter::AwesomePrint
+
+
+class Ey::Core::Cli::Main < Belafonte::App
+  title "Engineyard CLI"
+  summary "Successor to the engineyard gem"
+
+  require_relative "subcommand"
+  Dir[File.dirname(__FILE__) + '/*.rb'].
+    reject {|file| file =~ /.*\/main\.rb$/}.
+    each {|file| load file }
+
+  Ey::Core::Cli::Subcommand.descendants.each do |d|
+    mount d
+  end
+end


### PR DESCRIPTION
In order to make refactoring and such a bit more sane, this moves
the meat of the former Cli class to Cli::Main and leaves Cli as
a wrapper module.