### PR TITLE
Refactor cli recipes apply

### DIFF
--- a/lib/ey-core/cli/recipes/apply.rb
+++ b/lib/ey-core/cli/recipes/apply.rb
@@ -5,30 +5,48 @@ class Ey::Core::Cli::Recipes::Apply < Ey::Core::Cli::Recipes
   option :environment, short: "e", long: "environment", description: "Name or id of environment", argument: "environment"
 
   switch :main, short: "m", long: "main", description: "Apply main recipes only"
-  switch :custom, long: "custom", description: "Apply custom recipes only"
+  switch :custom, short: "u", long: "custom", description: "Apply custom recipes only"
   switch :quick, short: "q", long: "quick", description: "Quick chef run"
   switch :full, short: "f", long: "full", description: "Run main and custom chef"
 
+  SECONDARY_RUN_TYPES = {
+    custom: 'custom',
+    quick: 'quick'
+  }
+
+  DEFAULT_RUN_TYPE = 'main'
+
   def handle
+    validate_run_type_flags
+
     operator, environment = core_operator_and_environment_for(options)
     raise "Unable to find matching environment" unless environment
-
-    run_type = if switch_active?(:main)
-                 "main"
-               elsif switch_active?(:custom)
-                 "custom"
-               elsif switch_active?(:quick)
-                 "quick"
-               elsif switch_active?(:full)
-                 "main"
-               else
-                 "main"
-               end
 
     run_chef(run_type, environment)
 
     if switch_active?(:full)
       run_chef("custom", environment)
     end
+  end
+
+  private
+  def validate_run_type_flags
+    if active_run_type_flags.length > 1
+      kernel.abort(
+        'Only one of --main, --custom, --quick, and --full may be specified.'
+      )
+    end
+  end
+
+  def run_type
+    SECONDARY_RUN_TYPES[active_run_type] || DEFAULT_RUN_TYPE
+  end
+
+  def active_run_type
+    active_run_type_flags.first
+  end
+
+  def active_run_type_flags
+    [:main, :custom, :quick, :full].select {|switch| switch_active?(switch)}
   end
 end

--- a/lib/ey-core/cli/recipes/apply.rb
+++ b/lib/ey-core/cli/recipes/apply.rb
@@ -9,13 +9,6 @@ class Ey::Core::Cli::Recipes::Apply < Ey::Core::Cli::Recipes
   switch :quick, short: "q", long: "quick", description: "Quick chef run"
   switch :full, short: "f", long: "full", description: "Run main and custom chef"
 
-  SECONDARY_RUN_TYPES = {
-    custom: 'custom',
-    quick: 'quick'
-  }
-
-  DEFAULT_RUN_TYPE = 'main'
-
   def handle
     validate_run_type_flags
 
@@ -39,7 +32,7 @@ class Ey::Core::Cli::Recipes::Apply < Ey::Core::Cli::Recipes
   end
 
   def run_type
-    SECONDARY_RUN_TYPES[active_run_type] || DEFAULT_RUN_TYPE
+    secondary_run_types[active_run_type] || default_run_type
   end
 
   def active_run_type
@@ -48,5 +41,16 @@ class Ey::Core::Cli::Recipes::Apply < Ey::Core::Cli::Recipes
 
   def active_run_type_flags
     [:main, :custom, :quick, :full].select {|switch| switch_active?(switch)}
+  end
+
+  def secondary_run_types
+    {
+      custom: 'custom',
+      quick: 'quick'
+    }
+  end
+
+  def default_run_type
+    'main'
   end
 end

--- a/spec/ey-core/cli/recipes/apply_spec.rb
+++ b/spec/ey-core/cli/recipes/apply_spec.rb
@@ -7,15 +7,7 @@ require 'ey-core/cli/recipes'
 require 'ey-core/cli/recipes/apply'
 
 describe Ey::Core::Cli::Recipes::Apply do
-  let(:argv) {[]}
-  let(:stdout) {StringIO.new}
-  let(:stderr) {StringIO.new}
-  let(:stdin) {StringIO.new}
-  let(:kernel) {FakeKernel.new}
-  let(:apply) {described_class.new(argv, stdin, stdout, stderr, kernel)}
-  let(:execute) {apply.execute!}
-  let(:operator) {Object.new}
-  let(:environment) {Object.new}
+  set_up_cli
 
   before(:each) do
     allow_any_instance_of(described_class).
@@ -33,7 +25,7 @@ describe Ey::Core::Cli::Recipes::Apply do
     let(:argv) {['--main']}
 
     it 'performs a main chef run' do
-      expect(apply).to receive(:run_chef).with('main', environment)
+      expect(cli).to receive(:run_chef).with('main', environment)
 
       execute
       expect(kernel.exit_status).to eql(0)
@@ -44,7 +36,7 @@ describe Ey::Core::Cli::Recipes::Apply do
     let(:argv) {['--custom']}
 
     it 'performs a custom chef run' do
-      expect(apply).to receive(:run_chef).with('custom', environment)
+      expect(cli).to receive(:run_chef).with('custom', environment)
       
       execute
       expect(kernel.exit_status).to eql(0)
@@ -55,7 +47,7 @@ describe Ey::Core::Cli::Recipes::Apply do
     let(:argv) {['--quick']}
 
     it 'performs a quick chef run' do
-      expect(apply).to receive(:run_chef).with('quick', environment)
+      expect(cli).to receive(:run_chef).with('quick', environment)
       
       execute
       expect(kernel.exit_status).to eql(0)
@@ -66,8 +58,8 @@ describe Ey::Core::Cli::Recipes::Apply do
     let(:argv) {['--full']}
 
     it 'performs both a main and a custom chef run' do
-      expect(apply).to receive(:run_chef).with('main', environment)
-      expect(apply).to receive(:run_chef).with('custom', environment)
+      expect(cli).to receive(:run_chef).with('main', environment)
+      expect(cli).to receive(:run_chef).with('custom', environment)
       
       execute
       expect(kernel.exit_status).to eql(0)

--- a/spec/ey-core/cli/recipes/apply_spec.rb
+++ b/spec/ey-core/cli/recipes/apply_spec.rb
@@ -1,0 +1,99 @@
+require 'spec_helper'
+require 'stringio'
+require 'belafonte'
+require 'ey-core/cli'
+require 'ey-core/cli/subcommand'
+require 'ey-core/cli/recipes'
+require 'ey-core/cli/recipes/apply'
+
+describe Ey::Core::Cli::Recipes::Apply do
+  let(:argv) {[]}
+  let(:stdout) {StringIO.new}
+  let(:stderr) {StringIO.new}
+  let(:stdin) {StringIO.new}
+  let(:kernel) {FakeKernel.new}
+  let(:apply) {described_class.new(argv, stdin, stdout, stderr, kernel)}
+  let(:execute) {apply.execute!}
+  let(:operator) {Object.new}
+  let(:environment) {Object.new}
+
+  before(:each) do
+    allow_any_instance_of(described_class).
+      to receive(:core_operator_and_environment_for).
+      with(any_args).
+      and_return([operator, environment])
+
+    allow_any_instance_of(described_class).
+      to receive(:run_chef).
+      with(any_args).
+      and_return(true)
+  end
+
+  context 'ey-core recipes apply --main' do
+    let(:argv) {['--main']}
+
+    it 'performs a main chef run' do
+      expect(apply).to receive(:run_chef).with('main', environment)
+
+      execute
+      expect(kernel.exit_status).to eql(0)
+    end
+  end
+
+  context 'ey-core recipes apply --custom' do
+    let(:argv) {['--custom']}
+
+    it 'performs a custom chef run' do
+      expect(apply).to receive(:run_chef).with('custom', environment)
+      
+      execute
+      expect(kernel.exit_status).to eql(0)
+    end
+  end
+
+  context 'ey-core recipes apply --quick' do
+    let(:argv) {['--quick']}
+
+    it 'performs a quick chef run' do
+      expect(apply).to receive(:run_chef).with('quick', environment)
+      
+      execute
+      expect(kernel.exit_status).to eql(0)
+    end
+  end
+
+  context 'ey-core recipes apply --full' do
+    let(:argv) {['--full']}
+
+    it 'performs both a main and a custom chef run' do
+      expect(apply).to receive(:run_chef).with('main', environment)
+      expect(apply).to receive(:run_chef).with('custom', environment)
+      
+      execute
+      expect(kernel.exit_status).to eql(0)
+    end
+  end
+
+  context 'attempting to use more than one run type flag' do
+    let(:run_type_flags) {['--main', '--custom', '--quick', '--full']}
+    let(:combinations) {run_type_flags.combination(2).to_a}
+
+    it 'aborts with advice regarding the run type flags' do
+      expect(kernel).
+        to receive(:abort).
+        with('Only one of --main, --custom, --quick, and --full may be specified.').
+        and_call_original.
+        exactly(combinations.length).
+        times
+
+      combinations.each do |combination|
+        attempt = described_class.new(combination, stdin, stdout, stderr, kernel)
+
+        expect(attempt.execute!).not_to eql(0)
+
+
+
+      end
+    end
+  end
+end

--- a/spec/support/cli_helpers.rb
+++ b/spec/support/cli_helpers.rb
@@ -1,0 +1,11 @@
+def set_up_cli
+  let(:argv) {[]}
+  let(:stdout) {StringIO.new}
+  let(:stderr) {StringIO.new}
+  let(:stdin) {StringIO.new}
+  let(:kernel) {FakeKernel.new}
+  let(:cli) {described_class.new(argv, stdin, stdout, stderr, kernel)}
+  let(:execute) {cli.execute!}
+  let(:operator) {Object.new}
+  let(:environment) {Object.new}
+end

--- a/spec/support/fake_kernel.rb
+++ b/spec/support/fake_kernel.rb
@@ -1,0 +1,21 @@
+class FakeKernel
+  attr_reader :exit_status
+
+  def system(*args)
+    system_commands.push(args.join(' '))
+  end
+
+  def system_commands
+    @system_commands ||= []
+  end
+
+  def abort(msg)
+    self.exit(false)
+    #exit(false)
+  end
+
+  def exit(whatevs)
+    whatevs = -1 unless whatevs.is_a?(Integer)
+    @exit_status ||= whatevs
+  end
+end


### PR DESCRIPTION
This PR does the following:

* Specifies the behavior for the `ey-core recipes apply` command in terms of performing the different kinds of chef runs
* Clarifies the chef run behavior by limiting a single run to a single run type, enforcing the idea present in the descriptions of the relevant flags
* Adds a few simple helpers for specs to allow for easier acceptance testing of the Belafonte-derived portions of the app