### PR TITLE
Improvements to: deploy, status, environments

### DIFF
--- a/lib/ey-core/cli/accounts.rb
+++ b/lib/ey-core/cli/accounts.rb
@@ -8,7 +8,7 @@ module Ey
         summary "Retrieve a list of Engine Yard accounts that you have access to."
 
         def handle
-          table_data = TablePrint::Printer.new(current_accounts, [{id: {width: 36}}, :name])
+          table_data = TablePrint::Printer.new(core_accounts, [{id: {width: 36}}, :name])
           puts table_data.table_print
         end
       end

--- a/lib/ey-core/cli/applications.rb
+++ b/lib/ey-core/cli/applications.rb
@@ -27,7 +27,7 @@ module Ey
           if option(:account)
             core_account.applications.all
           else
-            current_accounts.map(&:applications).flatten.sort_by(&:id)
+            core_accounts.map(&:applications).flatten.sort_by(&:id)
           end
         end
       end

--- a/lib/ey-core/cli/helpers/log_streaming.rb
+++ b/lib/ey-core/cli/helpers/log_streaming.rb
@@ -1,0 +1,41 @@
+module Ey
+  module Core
+    module Cli
+      module Helpers
+        module LogStreaming
+
+          def stream_deploy_log(request)
+            if request.finished_at
+              return finished_request(request)
+            end
+            unless request.read_channel
+              puts "Unable to stream log (streaming not enabled for this deploy)".yellow
+              return
+            end
+            request.subscribe { |m| print m["message"] if m.is_a?(Hash) }
+            puts "" # fix console output from stream
+            finished_request(request)
+          end
+
+          def finished_request(request)
+            if request.successful
+              if request.resource.successful
+                puts "Deploy successful!".green
+              else
+                puts "Deploy failed!".red
+              end
+            else
+              abort <<-EOF
+        Deploy failed!
+        Request output:
+        #{request.message}
+              EOF
+              .red
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/ey-core/cli/helpers/stream_printer.rb
+++ b/lib/ey-core/cli/helpers/stream_printer.rb
@@ -1,0 +1,42 @@
+module Ey
+  module Core
+    module Cli
+      module Helpers
+        module StreamPrinter
+
+          def stream_print(opts)
+            yield Printer.new(opts)
+          end
+
+          class Printer
+            def initialize(rows = {})
+              @rows = rows
+            end
+            def print(*vals)
+              unless @header_printed
+                header = []
+                separator = []
+                @rows.each do |k,v|
+                  header << format(k, v)
+                  separator << '-' * v
+                end
+                puts header.join("| ")
+                puts separator.join("|-")
+                @header_printed = true
+              end
+              line = []
+              vals.each_with_index do |v,index|
+                line << format(v, @rows.values[index])
+              end
+              puts line.join("| ")
+            end
+            def format(value, width)
+              TablePrint::FixedWidthFormatter.new(width).format(value)
+            end
+          end
+
+        end
+      end
+    end
+  end
+end

--- a/lib/ey-core/cli/status.rb
+++ b/lib/ey-core/cli/status.rb
@@ -1,9 +1,11 @@
 require 'ey-core/cli/subcommand'
+require 'ey-core/cli/helpers/log_streaming'
 
 module Ey
   module Core
     module Cli
       class Status < Subcommand
+        include Ey::Core::Cli::Helpers::LogStreaming
         title "status"
         summary "Show the deployment status of the app"
         description <<-DESC
@@ -28,19 +30,30 @@ DESC
           description: "Application name or ID to deploy.  If :account is not specified, this will be the first app that matches the criteria in the accounts you have access to.",
           argument: "app"
 
+        switch :tail,
+          long: "tail",
+          description: "tail in-progress deployment log"
+
         def handle
           operator, environment = core_operator_and_environment_for(self.options)
-          deployments = core_client.
-            deployments.
-            all(environment_id: environment.id, application_id: app.id)
+          app                   = core_application_for(environment, self.options)
+          deploy                = environment.latest_deploy(app)
 
-          ap deployments.first
+          puts environment.release_label
+          puts "#{environment.servers.size} servers"
+          environment.servers.each do |s|
+            puts [s.provisioned_id, s.role, s.state].join(" ")
+          end
+          if deploy
+            ap deploy
+            if switch_active?(:tail)
+              stream_deploy_log(deploy.request)
+            end
+          else
+            puts "Never Deployed"
+          end
         end
 
-        private
-        def app
-          core_application_for(options)
-        end
       end
     end
   end

--- a/lib/ey-core/cli/subcommand.rb
+++ b/lib/ey-core/cli/subcommand.rb
@@ -16,6 +16,37 @@ module Ey
           $stdin = stdin
           $kernel = kernel
         end
+
+        def run_handle
+          super
+        rescue Ey::Core::Response::Error => e
+          if ENV["DEBUG"]
+            puts e.inspect
+            puts e.backtrace
+          end
+          handle_core_error(e)
+        rescue => e
+          if ENV["DEBUG"]
+            puts e.inspect
+            puts e.backtrace
+          end
+          stderr.puts "Error:".red
+          stderr.puts Wrapomatic.wrap(e.message, indents: 1)
+          raise SystemExit.new(255)
+        end
+
+        #TODO: a lot more errors that would could handle with nice messages, eventually this should probably be it's own class
+        def handle_core_error(e)
+          stderr.puts "Error: #{e.error_type}".red
+          (e.response.body["errors"] || [e.message]).each do |message|
+            stderr.puts Wrapomatic.wrap(message, indents: 1)
+          end
+          if e.is_a?(Ey::Core::Response::Unauthorized)
+            stderr.puts "Check the contents of ~/.ey-core vs https://cloud.engineyard.com/cli"
+          end
+          raise SystemExit.new(255)
+        end
+
       end
     end
   end

--- a/lib/ey-core/cli/timeout_deploy.rb
+++ b/lib/ey-core/cli/timeout_deploy.rb
@@ -42,6 +42,7 @@ DESC
 
         def handle
           operator, environment = core_operator_and_environment_for(self.options)
+          app                   = core_application_for(environment, options)
           deployment = core_client.
             deployments.
             first(environment_id: environment.id, application_id: app.id)
@@ -50,11 +51,6 @@ DESC
 
           deployment.timeout(option(:message))
           ap deployment
-        end
-
-        private
-        def app
-          core_application_for(options)
         end
       end
     end

--- a/lib/ey-core/cli/web/disable.rb
+++ b/lib/ey-core/cli/web/disable.rb
@@ -28,7 +28,7 @@ module Ey
 
           def handle
             operator, environment = core_operator_and_environment_for(self.options)
-            application = core_application_for(self.options)
+            application           = core_application_for(environment, self.options)
 
             puts "Enabling maintenance page for #{application.name} on #{environment.name}".green
 

--- a/lib/ey-core/cli/web/enable.rb
+++ b/lib/ey-core/cli/web/enable.rb
@@ -28,6 +28,7 @@ module Ey
 
           def handle
             operator, environment = core_operator_and_environment_for(self.options)
+            application           = core_application_for(environment, options)
             puts "Disabling maintenance for #{application.name} on #{environment.name}".green
             request = environment.maintenance(application, "disable")
             request.wait_for { |r| r.ready? }
@@ -37,11 +38,6 @@ module Ey
               puts "Disabling maintenance mode was not successful".red
               ap request
             end
-          end
-
-          private
-          def application
-            core_application_for(options)
           end
         end
       end

--- a/lib/ey-core/model.rb
+++ b/lib/ey-core/model.rb
@@ -7,6 +7,11 @@ class Ey::Core::Model < Cistern::Model
     end
   end
 
+  def to_s
+    shortname = self.class.name.split("::").last
+    "#{shortname}:#{id}"
+  end
+
   def self.range_parser(v)
     case v
     when Range then

--- a/lib/ey-core/models/deployment.rb
+++ b/lib/ey-core/models/deployment.rb
@@ -11,11 +11,18 @@ class Ey::Core::Client::Deployment < Ey::Core::Model
   attribute :resolved_ref
   attribute :started_at,     type: :time
   attribute :successful,     type: :boolean
+  attribute :verbose
+  attribute :streaming
+  attribute :request_url, aliases: :request
 
   has_one :account
   has_one :environment
   has_one :application
   has_one :user
+
+  def request
+    self.request_url && self.connection.requests.get(self.request_url.split("/").last)
+  end
 
   def timeout(message=nil)
     merge_attributes(self.connection.timeout_deployment("id" => self.id, "message" => message).body["deployment"])

--- a/lib/ey-core/models/environment.rb
+++ b/lib/ey-core/models/environment.rb
@@ -31,6 +31,11 @@ class Ey::Core::Client::Environment < Ey::Core::Model
 
   attr_accessor :application_id
 
+  def latest_deploy(app)
+    deployments = connection.deployments.all(environment_id: self.id, application_id: app.id)
+    deployments.first
+  end
+
   # @param application [Ey::Core::Client::Application]
   # @option opts [Ey::Core::Client::ApplicationArchive] :archive
   def deploy(application, opts={})

--- a/lib/ey-core/models/request.rb
+++ b/lib/ey-core/models/request.rb
@@ -65,6 +65,8 @@ class Ey::Core::Client::Request < Ey::Core::Model
       self.connection.database_servers.get!(resource_id)
     when /database_service/
       self.connection.database_services.get!(resource_id)
+    when /deployment/
+      self.connection.deployments.get!(resource_id)
     when /firewall(?!_rule)/
       self.connection.firewalls.get!(resource_id)
     when /firewall_rule/

--- a/lib/ey-core/models/user.rb
+++ b/lib/ey-core/models/user.rb
@@ -9,6 +9,7 @@ class Ey::Core::Client::User < Ey::Core::Model
   attribute :deleted_at
 
   has_many :accounts
+  has_many :environments
   has_many :keypairs
   has_many :tokens
 
@@ -33,4 +34,5 @@ class Ey::Core::Client::User < Ey::Core::Model
   def destroy!
     self.connection.destroy_user("id" => self.id) && true
   end
+
 end

--- a/lib/ey-core/response.rb
+++ b/lib/ey-core/response.rb
@@ -13,6 +13,10 @@ class Ey::Core::Response
         }.inspect
       )
     end
+
+    def error_type
+      self.class.name.split(":").last
+    end
   end
 
   BadRequest        = Class.new(Error)

--- a/lib/ey-core/subscribable.rb
+++ b/lib/ey-core/subscribable.rb
@@ -30,17 +30,17 @@ module Ey::Core::Subscribable
       end
 
       deferred.callback do
-        block.call({"meta" => true, "created_at" => Time.now,"message" => "successfully subscribed"})
+        block.call({"meta" => true, "created_at" => Time.now,"message" => "successfully connected to log streaming service\n"})
       end
 
       deferred.errback do |error|
-        block.call({"meta" => true, "created_at" => Time.now, "message" => "subscription failed: #{error.inspect}"})
+        block.call({"meta" => true, "created_at" => Time.now, "message" => "failed to stream output: #{error.inspect}\n"})
         EM.stop_event_loop
       end
 
       EventMachine::PeriodicTimer.new(5) do
         if resource.reload.ready?
-          block.call({"meta" => true, "created_at" => Time.now, "message" => "#{resource} is finished"})
+          block.call({"meta" => true, "created_at" => Time.now, "message" => "#{resource} finished"})
           EM.stop_event_loop
         end
       end

--- a/spec/support/cli_helpers.rb
+++ b/spec/support/cli_helpers.rb
@@ -21,7 +21,7 @@ def set_up_cli
       and_return([client, environment])
 
     allow_any_instance_of(described_class).
-      to receive(:current_accounts).
+      to receive(:core_accounts).
       and_return([account])
   end
 end


### PR DESCRIPTION
Added no-wait option on `deploy` to background the deploy instead of
waiting for it to complete

Removed stream option on `deploy`, stream is ON by default, if you
didn't want streaming you probably wanted --no-wait

The verbose option on `deploy` actually controls the --verbose flag
sent to serverside (some log output on deploys or lots of log output on
dpeloys)

On deploys if --ref is not provided, attempt to lookup most recent
deploy and use the same ref

On deploys if no migrate option is provided, attempt to lookup most
recent deploy and use the same

More helpful error messages related to --ref and --migrate options on
deploy

`environments` command now streams it's output so that if you have
more than 20 environments you aren't waiting for each page to load
before the output

fetching of accounts and environments will only return ones you
collaborate on unless you provide the STAFF environment variable (and
you are actually EY staff) in which case you could act on any account or
environment.

better error messaging and suggestions when cannot find account or
environment

--app option can now be skipped if an environment has only 1 app

better error messaging when app can't be found (tells you possibilities)

DEBUG env var prints full stack traces and full log of Core API
requests

status supports --tail to view the log of a running deploy