### PR TITLE
Support mocks of account_trial data

### DIFF
--- a/lib/ey-core/client/mock.rb
+++ b/lib/ey-core/client/mock.rb
@@ -108,6 +108,7 @@ class Ey::Core::Client::Mock
                {
                  :account_referrals           => {},
                  :accounts                    => {},
+                 :account_trials              => {},
                  :addons                      => {},
                  :addresses                   => {},
                  :agents                      => {},
@@ -203,6 +204,14 @@ class Ey::Core::Client::Mock
         @current_user ||= begin
                             _,found = self.data[:users].detect{|k,v| v["token"] == options[:token]}
                             found
+                          end
+
+        @current_user ||= begin
+                            _,token = self.data[:tokens].detect{|k,v| v["auth_id"] == options[:token]}
+                            if token
+                              user_id = token["on_behalf_of"].split("/").last
+                              self.data[:users][user_id]
+                            end
                           end
 
         # FIXME(rs) get rid of this and the implicit Josh Lane creation entirely

--- a/lib/ey-core/requests/get_account_trial.rb
+++ b/lib/ey-core/requests/get_account_trial.rb
@@ -14,13 +14,14 @@ class Ey::Core::Client
 
       find(:accounts, account_id)
 
-      resource = {
+      resource = self.data[:account_trials][account_id]
+      resource ||= {
         "id"         => Cistern::Mock.random_numbers(4),
         "duration"   => 500,
         "used"       => 30,
         "created_at" => Time.now.to_s,
-        "account"    => url_for("/accounts/#{account_id}")
       }
+      resource["account"] = url_for("/accounts/#{account_id}")
 
       response(
         :body   => {"account_trial" => resource},


### PR DESCRIPTION
Consumers of core API can put mock data in :account_trials
and calls to get_account_trial request will reflect it

Update mocks system for current_user to also check the :tokens data to
see if a user matches the token given