### PR TITLE
Adjust recipe upload and apply for lastest stack

### DIFF
--- a/lib/ey-core/cli/helpers/chef.rb
+++ b/lib/ey-core/cli/helpers/chef.rb
@@ -14,6 +14,9 @@ module Ey
             else
               puts "#{type.capitalize} chef run failed".red
               ap request
+              if server = environment.servers.first
+                puts "For logs try `ey logs --server #{server.provisioned_id}` --environment #{environment.name}"
+              end
             end
           end
 
@@ -25,7 +28,7 @@ module Ey
             elsif recipes_path.exist?
               environment.upload_recipes(archive_directory(path))
             else
-              raise RecipesNotFound, "Recipes file not found: #{recipes_path}"
+              raise RecipesNotFound, "Recipes not found, expected to find chef recipes in: #{File.expand_path(recipes_path)}"
             end
           end
         end

--- a/lib/ey-core/cli/recipes/apply.rb
+++ b/lib/ey-core/cli/recipes/apply.rb
@@ -23,72 +23,24 @@ module Ey
             description: "Name or id of environment",
             argument: "environment"
 
-          switch :main,
-            short: "m",
-            long: "main",
-            description: "Apply main recipes only"
-
-          switch :custom,
-            short: "u",
-            long: "custom",
-            description: "Apply custom recipes only"
-
           switch :quick,
             short: "q",
             long: "quick",
-            description: "Quick chef run"
-
-          switch :full,
-            short: "f",
-            long: "full",
-            description: "Run main and custom chef"
+            description: "Quick chef run (if not specified, will run main chef run)"
 
           def handle
-            validate_run_type_flags
-
             operator, environment = core_operator_and_environment_for(options)
             raise "Unable to find matching environment" unless environment
 
             run_chef(run_type, environment)
-
-            if switch_active?(:full)
-              run_chef("custom", environment)
-            end
           end
 
           private
-          def validate_run_type_flags
-            if active_run_type_flags.length > 1
-              kernel.abort(
-                'Only one of --main, --custom, --quick, and --full may be specified.'
-              )
-            end
-          end
 
           def run_type
-            secondary_run_types[active_run_type] || default_run_type
+            (switch_active?(:quick) && "quick") || "main"
           end
 
-          def active_run_type
-            active_run_type_flags.first
-          end
-
-          def active_run_type_flags
-            [:main, :custom, :quick, :full].select {|switch|
-              switch_active?(switch)
-            }
-          end
-
-          def secondary_run_types
-            {
-              custom: 'custom',
-              quick: 'quick'
-            }
-          end
-
-          def default_run_type
-            'main'
-          end
         end
       end
     end

--- a/lib/ey-core/cli/recipes/upload.rb
+++ b/lib/ey-core/cli/recipes/upload.rb
@@ -46,11 +46,12 @@ module Ey
               upload_recipes(environment, path)
               puts "Uploading custom recipes complete".green
             rescue => e
+              puts e.message
               abort "There was a problem uploading the recipes".red
             end
 
             if switch_active?(:apply)
-              run_chef("custom", environment)
+              run_chef("main", environment)
             end
           end
         end

--- a/lib/ey-core/models/log.rb
+++ b/lib/ey-core/models/log.rb
@@ -3,7 +3,7 @@ class Ey::Core::Client::Log < Ey::Core::Model
 
   identity :id
 
-  attribute :created_at
+  attribute :created_at, type: :time
   attribute :filename
   attribute :mime_type
   attribute :download_url

--- a/spec/ey-core/cli/recipes/apply_spec.rb
+++ b/spec/ey-core/cli/recipes/apply_spec.rb
@@ -11,23 +11,10 @@ describe Ey::Core::Cli::Recipes::Apply do
       and_return(true)
   end
 
-  context 'ey-core recipes apply --main' do
-    arguments '--main'
-
+  context 'ey-core recipes apply' do
     it 'performs a main chef run' do
       expect(cli).to receive(:run_chef).with('main', environment)
 
-      execute
-      expect(kernel.exit_status).to eql(0)
-    end
-  end
-
-  context 'ey-core recipes apply --custom' do
-    arguments '--custom'
-
-    it 'performs a custom chef run' do
-      expect(cli).to receive(:run_chef).with('custom', environment)
-      
       execute
       expect(kernel.exit_status).to eql(0)
     end
@@ -44,35 +31,4 @@ describe Ey::Core::Cli::Recipes::Apply do
     end
   end
 
-  context 'ey-core recipes apply --full' do
-    arguments '--full'
-
-    it 'performs both a main and a custom chef run' do
-      expect(cli).to receive(:run_chef).with('main', environment)
-      expect(cli).to receive(:run_chef).with('custom', environment)
-      
-      execute
-      expect(kernel.exit_status).to eql(0)
-    end
-  end
-
-  context 'attempting to use more than one run type flag' do
-    let(:run_type_flags) {['--main', '--custom', '--quick', '--full']}
-    let(:combinations) {run_type_flags.combination(2).to_a}
-
-    it 'aborts with advice regarding the run type flags' do
-      expect(kernel).
-        to receive(:abort).
-        with('Only one of --main, --custom, --quick, and --full may be specified.').
-        and_call_original.
-        exactly(combinations.length).
-        times
-
-      combinations.each do |combination|
-        attempt = described_class.new(combination, stdin, stdout, stderr, kernel)
-
-        expect(attempt.execute!).not_to eql(0)
-      end
-    end
-  end
 end

--- a/spec/ey-core/cli/recipes/upload_spec.rb
+++ b/spec/ey-core/cli/recipes/upload_spec.rb
@@ -62,7 +62,7 @@ describe Ey::Core::Cli::Recipes::Upload do
     arguments '--apply'
 
     it 'performs a custom chef run' do
-      expect(cli).to receive(:run_chef).with('custom', environment)
+      expect(cli).to receive(:run_chef).with('main', environment)
 
       execute
     end


### PR DESCRIPTION
No longer a command to run just custom chef, must run "main" run which
includes both main and custom. In pre-v5 they are run sequentially, in
v5 custom is an overlay on main.

Output information about viewing logs after chef run commands.