### PR TITLE
Factor in passed client for resource creation

### DIFF
--- a/lib/ey-core/test_helpers/account_helpers.rb
+++ b/lib/ey-core/test_helpers/account_helpers.rb
@@ -3,8 +3,8 @@ module Ey
     module TestHelpers
       module AccountHelpers
         def create_account(options={})
-          creator = options[:creator] || create_client
-          client  = options[:client]
+          client = options[:client]
+          creator = options[:creator] || client || create_client
 
           attributes = options[:account] || {}
           attributes[:type] ||= "beta" # get around awsm billing requirements for tests
@@ -28,8 +28,8 @@ module Ey
         end
 
         def create_user(options={})
-          creator = options[:creator] || create_client
-          client  = options[:client]
+          client = options[:client]
+          creator = options[:creator] || client || create_client
 
           attributes = options[:user] || {}
           attributes[:name] ||= Faker::Name.name


### PR DESCRIPTION
Previously, in order to ensure that the same client object
was used to create resources as is used in the rest of a test,
one had to pass both "client" and "creator" to `create_user`
and `create_account`:

```
create_user(client: some_client, creator: some_cilent)
```

Otherwise, creator gets a brand new Ey::Core::Client instance
that may or may not be compatible with the client used in
the rest of the system.

The change in this commit implements the following creator rules:

* If a :creator option is passed, that is used for resource creation
* Othwersie, if a :client option is passed, that is used
* Failing all else, a brand new, dubiously-created client instance
  is used