### PR TITLE
Endpoint for server reconcile

### DIFF
--- a/lib/ey-core/client.rb
+++ b/lib/ey-core/client.rb
@@ -289,6 +289,7 @@ class Ey::Core::Client < Cistern::Service
   request :get_users
   request :get_volumes
   request :reboot_server
+  request :reconcile_server
   request :request_callback
   request :reset_password
   request :reset_server_state

--- a/lib/ey-core/models/server.rb
+++ b/lib/ey-core/models/server.rb
@@ -77,6 +77,14 @@ class Ey::Core::Client::Server < Ey::Core::Model
     )
   end
 
+  def reconcile
+    requires :identity
+
+    connection.requests.new(
+      self.connection.reconcile_server("id" => self.identity).body["request"]
+    )
+  end
+
   def reset_state(state)
     params = {
       "url"   => self.collection.url,

--- a/lib/ey-core/requests/reconcile_server.rb
+++ b/lib/ey-core/requests/reconcile_server.rb
@@ -1,0 +1,39 @@
+class Ey::Core::Client
+  class Real
+    def reconcile_server(params={})
+      id  = params["id"]
+      url = params["url"]
+
+      request(
+        :method => :put,
+        :path   => "servers/#{id}/reconcile",
+        :url    => url,
+      )
+    end
+  end # Real
+
+  class Mock
+    def reconcile_server(params={})
+      request_id  = self.uuid
+      identity = resource_identity(params)
+
+      find(:servers, identity)
+
+      reconcile_request = {
+        "finished_at" => Time.now,
+        "id"          => request_id,
+        "started_at"  => Time.now,
+        "successful"  => "true",
+        "server"      => url_for("/servers/#{identity}"),
+        "type"        => "reconcile_server_request",
+      }
+
+      self.data[:requests][request_id] = reconcile_request
+
+      response(
+        :body   => {"request" => reconcile_request},
+        :status => 201,
+      )
+    end
+  end # Mock
+end

--- a/spec/servers_spec.rb
+++ b/spec/servers_spec.rb
@@ -46,6 +46,12 @@ describe 'servers' do
       expect(request.successful).to be true
     end
 
+    it "reconciles" do
+      request = server.reconcile
+      request.ready!
+      expect(request.successful).to be true
+    end
+
     it "applies" do
       expect(server.apply.ready!).to be_successful
 


### PR DESCRIPTION
detects if a server's state in amazon mismatches what's showing on the
dashboard and adjusts appropriately