### PR TITLE
Pass `skip_snapshot` when deleting a server

### DIFF
--- a/lib/ey-core/models/server.rb
+++ b/lib/ey-core/models/server.rb
@@ -131,15 +131,19 @@ class Ey::Core::Client::Server < Ey::Core::Model
     end
   end
 
-  def destroy!
+  def destroy!(skip_snapshot="false")
     if environment.servers.count == 1
       raise Ey::Core::Client::NotPermitted, "Terminating the last server in an environment is not allowed.  You must deprovision or destroy the environment instead."
     end
 
     requires :identity
 
+    params = {
+       :skip_snapshot => skip_snapshot
+    }
+
     connection.requests.new(
-      self.connection.destroy_server(self.identity).body["request"]
+      self.connection.destroy_server(self.identity, params).body["request"]
     )
   end
 end

--- a/lib/ey-core/requests/destroy_server.rb
+++ b/lib/ey-core/requests/destroy_server.rb
@@ -1,7 +1,7 @@
 class Ey::Core::Client
   class Real
     def destroy_server(id,options={})
-      
+
       request(
         :method => :delete,
         :path => "/servers/#{id}",
@@ -11,7 +11,7 @@ class Ey::Core::Client
   end
 
   class Mock
-    def destroy_server(id)
+    def destroy_server(id,options={})
       deprovision_procedure = lambda do |_|
         server = self.data[:servers][id]
 

--- a/lib/ey-core/requests/destroy_server.rb
+++ b/lib/ey-core/requests/destroy_server.rb
@@ -1,9 +1,11 @@
 class Ey::Core::Client
   class Real
-    def destroy_server(id)
+    def destroy_server(id,options={})
+      
       request(
         :method => :delete,
-        :path => "/servers/#{id}"
+        :path => "/servers/#{id}",
+        :query => options
       )
     end
   end


### PR DESCRIPTION
Allow to change default behaviour when calling `server.destroy!` by passing the value of `skip_snapshot` to the DELETE request.