### PR TITLE
Fixes regression from ENG-965

### DIFF
--- a/lib/ey-core/cli/ssh.rb
+++ b/lib/ey-core/cli/ssh.rb
@@ -117,6 +117,12 @@ module Ey
                 db_master: switch_active?(:db_master),
                 utilities: option(:utilities)
               )
+
+              # Reinstate default behavior: If no command is passed and no
+              # roles are passed, open a connection to the app master
+              if servers.empty?
+                servers += (environment.servers.all(role: "app_master") + environment.servers.all(role: "solo")).to_a
+              end
             end
           end
 


### PR DESCRIPTION
In #68, the behavior of `ey-core ssh` was inadvertently changed
for the non-command (open a shell) case, but this behavior was
not documented.

This commit doesn't revert the change from #68, but does restore
the default behavior such that if no command is passed and no
role is passed, the app_master/solo instance in the environment
is explicitly added to the list of servers to use for the
connection.