### PR TITLE
ey-core ssh: `option[]` bad, `option()` good

### DIFF
--- a/lib/ey-core/cli/ssh.rb
+++ b/lib/ey-core/cli/ssh.rb
@@ -107,7 +107,7 @@ module Ey
             end
 
             if option(:server)
-              servers += [core_server_for(server: option[:server], operator: environment)]
+              servers += [core_server_for(server: option(:server), operator: environment)]
             else
               servers += Ey::Core::Cli::Helpers::ServerSieve.filter(
                 environment.servers,


### PR DESCRIPTION
This should at least partially fix specifying an instance ID when
using `ey-core ssh`