### PR TITLE
Server cli improvements

### DIFF
--- a/lib/ey-core/cli/servers.rb
+++ b/lib/ey-core/cli/servers.rb
@@ -19,6 +19,12 @@ module Ey
           description: 'Filter by environment.',
           argument: 'environment'
 
+        option :role,
+          short: 'r',
+          long: 'role',
+          description: 'Filter by server role.',
+          argument: 'role'
+
         def handle
           puts TablePrint::Printer.
             new(servers, [{id: {width: 10}}, :role, :provisioned_id]).
@@ -37,6 +43,7 @@ module Ey
               core_client
             end
 
+          filter_opts[:role] = option(:role).split(',') if option(:role)
           operator ? operator.servers.all(filter_opts) : nil
         end
       end

--- a/lib/ey-core/cli/servers.rb
+++ b/lib/ey-core/cli/servers.rb
@@ -26,9 +26,15 @@ module Ey
           argument: 'role'
 
         def handle
-          puts TablePrint::Printer.
-            new(servers, [{id: {width: 10}}, :role, :provisioned_id]).
-            table_print
+          puts TablePrint::Printer.new(
+            servers,
+            [
+              { id: { width: 10 } },
+              :role,
+              :provisioned_id,
+              { public_hostname: { width: 50 } }
+            ]
+          ).table_print
         end
 
         private

--- a/lib/ey-core/cli/servers.rb
+++ b/lib/ey-core/cli/servers.rb
@@ -4,20 +4,20 @@ module Ey
   module Core
     module Cli
       class Servers < Subcommand
-        title "servers"
-        summary "List servers you have access to"
+        title 'servers'
+        summary 'List servers you have access to'
 
         option :account,
           short: 'c',
           long: 'account',
           description: 'Filter by account name or id',
-          argument: 'Account'
+          argument: 'account'
 
         option :environment,
-          short: "-e",
-          long: "environment",
-          description: "Filter by environment.",
-          argument: "environment"
+          short: 'e',
+          long: 'environment',
+          description: 'Filter by environment.',
+          argument: 'environment'
 
         def handle
           puts TablePrint::Printer.
@@ -27,13 +27,17 @@ module Ey
 
         private
         def servers
-          if option(:account)
-            core_client.servers.all(account: core_account)
-          elsif environment = option(:environment)
-            (core_client.environments.get(environment) || core_client.environments.first(name: environment)).servers.all
-          else
-            core_client.servers.all
-          end
+          filter_opts = {}
+
+          operator =
+            if option(:environment)
+              core_account.environments.first(name: option(:environment))
+            else
+              filter_opts[:account] = core_account.id if option(:account)
+              core_client
+            end
+
+          operator ? operator.servers.all(filter_opts) : nil
         end
       end
     end


### PR DESCRIPTION
After transitioning our project to Ruby 2.4 we started using `ey-core` instead of `ey` due to some issues with `ey`. We have multiple accounts with the same environment names (e.g. "production" and "staging") and existing implementation:

1. Was broken in terms of filtering by account.
2. Had an incorrect short flag for environments.
3. Made it impossible to get the servers for an environment that had the same name as an environment of the default account.

Additionally, the table output has been altered to include the public hostname. In our own use cases for `ey` this was probably the most regularly used information.