### PR TITLE
Loosened dependency on json gem.  

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,6 +4,7 @@ source 'https://rubygems.org'
 gemspec
 
 gem "rack", "<= 2.0"
+gem "json", "> 1.8.5", '< 2.2'
 
 group :doc do
   gem 'yard'

--- a/ey-core.gemspec
+++ b/ey-core.gemspec
@@ -33,7 +33,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency "rack"
   gem.add_dependency "faye"
   gem.add_dependency "highline"
-  gem.add_dependency "json", "< 2.0"
+  gem.add_dependency "json", "> 1.8.5", "<2.2.0"
   gem.add_dependency "mime-types"
   gem.add_dependency "oj"
   gem.add_dependency "oj_mimic_json"


### PR DESCRIPTION
This allows developers to include ey-core in their development group of bundler while still using the json version their app relies on.

Including ey-core in your Gemfile eases the life of developers, especially when hiring new recruits.