### PR TITLE
Implement Core API for retrieving docker authorization

### DIFF
--- a/features/docker_registry_credentials.feature
+++ b/features/docker_registry_credentials.feature
@@ -1,0 +1,21 @@
+Feature: Docker Registry Credentials
+  In order to authorize the Docker Engine with the AWS ECR registry
+  As a User
+  I want to be able to retrieve the Docker authorization credentials
+
+  Background:
+    Given I'm an Engine Yard user
+    And ey-core is configured with my cloud token
+    And I have the following accounts:
+      | Account Name  |
+      | one           |
+      | two           |
+
+  Scenario Outline: Retrieving Docker authorization credentials
+    When I run `ey-core get-docker-registry-login <Account Flag> one <Location Flag> us-east-1`
+    Then I see the docker login command
+
+    Examples:
+      | Account Flag  | Location Flag |
+      | -c            | -l            |
+      | --account     | --location    |

--- a/features/step_definitions/docker_registry_credentials_steps.rb
+++ b/features/step_definitions/docker_registry_credentials_steps.rb
@@ -1,0 +1,3 @@
+Then %(I see the docker login command) do
+  expect(output_text).to match("docker login -u foo -p bar https://012345678901.dkr.ecr.us-east-1.amazonaws.com")
+end

--- a/lib/ey-core/cli/docker_registry_login.rb
+++ b/lib/ey-core/cli/docker_registry_login.rb
@@ -1,0 +1,29 @@
+require 'ey-core/cli/subcommand'
+
+module Ey
+  module Core
+    module Cli
+      class DockerRegistryLogin < Subcommand
+        title "get-docker-registry-login"
+        summary "Prints the docker login command to authorize the Docker Engine with the AWS ECR registry"
+
+        option :account,
+               short:       'c',
+               long:        'account',
+               description: 'Name or ID of the account that the environment resides in.',
+               argument:    'Account name or id'
+
+        option :location,
+               short:       'l',
+               long:        'location',
+               description: 'ECR availability regions',
+               argument:    'Location name'
+
+        def handle
+          credentials = core_account.retrieve_docker_registry_credentials(option(:location))
+          stdout.puts "docker login -u #{credentials.username} -p #{credentials.password} #{credentials.registry_endpoint}"
+        end
+      end
+    end
+  end
+end

--- a/lib/ey-core/cli/main.rb
+++ b/lib/ey-core/cli/main.rb
@@ -13,6 +13,7 @@ require 'ey-core/cli/applications'
 require 'ey-core/cli/console'
 require 'ey-core/cli/current_user'
 require 'ey-core/cli/deploy'
+require 'ey-core/cli/docker_registry_login'
 require 'ey-core/cli/environments'
 require 'ey-core/cli/environment_variables'
 require 'ey-core/cli/help'
@@ -45,6 +46,7 @@ module Ey
         mount Console
         mount CurrentUser
         mount Deploy
+        mount DockerRegistryLogin
         mount Environments
         mount EnvironmentVariables
         mount Help

--- a/lib/ey-core/client.rb
+++ b/lib/ey-core/client.rb
@@ -90,6 +90,7 @@ class Ey::Core::Client < Cistern::Service
   model :database_server_usage
   model :database_service
   model :deployment
+  model :docker_registry_credentials
   model :environment
   model :environment_plan_usage
   model :environment_variable
@@ -321,6 +322,7 @@ class Ey::Core::Client < Cistern::Service
   request :reset_password
   request :reset_server_state
   request :restart_environment_app_servers
+  request :retrieve_docker_registry_credentials
   request :run_cluster_application_action
   request :run_environment_application_action
   request :signup

--- a/lib/ey-core/client.rb
+++ b/lib/ey-core/client.rb
@@ -90,7 +90,6 @@ class Ey::Core::Client < Cistern::Service
   model :database_server_usage
   model :database_service
   model :deployment
-  model :docker_registry_credentials
   model :environment
   model :environment_plan_usage
   model :environment_variable

--- a/lib/ey-core/models/account.rb
+++ b/lib/ey-core/models/account.rb
@@ -67,4 +67,12 @@ class Ey::Core::Client::Account < Ey::Core::Model
     else raise NotImplementedError # update
     end
   end
+
+  # Get authorization data for an Amazon ECR registry.
+  # @param [String] location_id Aws region
+  # @return [Ey::Core::Client::DockerRegistryCredentials]
+  def retrieve_docker_registry_credentials(location_id)
+    result = self.connection.retrieve_docker_registry_credentials(self.id, location_id).body
+    Ey::Core::Client::DockerRegistryCredentials.new(result['docker_registry_credentials'])
+  end
 end

--- a/lib/ey-core/models/account.rb
+++ b/lib/ey-core/models/account.rb
@@ -1,3 +1,5 @@
+require 'hashie'
+
 class Ey::Core::Client::Account < Ey::Core::Model
   extend Ey::Core::Associations
 
@@ -70,9 +72,9 @@ class Ey::Core::Client::Account < Ey::Core::Model
 
   # Get authorization data for an Amazon ECR registry.
   # @param [String] location_id Aws region
-  # @return [Ey::Core::Client::DockerRegistryCredentials]
+  # @return [Hashie::Mash]
   def retrieve_docker_registry_credentials(location_id)
     result = self.connection.retrieve_docker_registry_credentials(self.id, location_id).body
-    Ey::Core::Client::DockerRegistryCredentials.new(result['docker_registry_credentials'])
+    ::Hashie::Mash.new(result['docker_registry_credentials'])
   end
 end

--- a/lib/ey-core/models/docker_registry_credentials.rb
+++ b/lib/ey-core/models/docker_registry_credentials.rb
@@ -1,0 +1,6 @@
+class Ey::Core::Client::DockerRegistryCredentials < Ey::Core::Model
+  attribute :username
+  attribute :password
+  attribute :registry_endpoint
+  attribute :expires_at, type: :time
+end

--- a/lib/ey-core/models/docker_registry_credentials.rb
+++ b/lib/ey-core/models/docker_registry_credentials.rb
@@ -1,6 +1,0 @@
-class Ey::Core::Client::DockerRegistryCredentials < Ey::Core::Model
-  attribute :username
-  attribute :password
-  attribute :registry_endpoint
-  attribute :expires_at, type: :time
-end

--- a/lib/ey-core/requests/retrieve_docker_registry_credentials.rb
+++ b/lib/ey-core/requests/retrieve_docker_registry_credentials.rb
@@ -15,7 +15,7 @@ class Ey::Core::Client
             'username'          => 'foo',
             'password'          => 'bar',
             'registry_endpoint' => "https://012345678901.dkr.ecr.#{location_id}.amazonaws.com",
-            'expires_at'        => Time.now + 8 * 3600
+            'expires_at'        => (Time.now + 8 * 3600).to_i
           }
         }
       )

--- a/lib/ey-core/requests/retrieve_docker_registry_credentials.rb
+++ b/lib/ey-core/requests/retrieve_docker_registry_credentials.rb
@@ -1,0 +1,24 @@
+class Ey::Core::Client
+  class Real
+    def retrieve_docker_registry_credentials(account_id, location_id)
+      request(
+        :path => "/accounts/#{account_id}/docker-registry/#{location_id}/credentials"
+      )
+    end
+  end
+
+  class Mock
+    def retrieve_docker_registry_credentials(account_id, location_id)
+      response(
+        :body => {
+          'docker_registry_credentials' => {
+            'username'          => 'foo',
+            'password'          => 'bar',
+            'registry_endpoint' => "https://012345678901.dkr.ecr.#{location_id}.amazonaws.com",
+            'expires_at'        => Time.now + 8 * 3600
+          }
+        }
+      )
+    end
+  end
+end

--- a/spec/docker_registry_credentials_spec.rb
+++ b/spec/docker_registry_credentials_spec.rb
@@ -1,0 +1,16 @@
+require 'spec_helper'
+
+describe 'as a user' do
+  let(:client) { create_client }
+  let(:location) { 'us-east-1' }
+  let!(:account) { create_account(client: client) }
+
+  it 'returns a valid docker registry credentials' do
+    credentials = account.retrieve_docker_registry_credentials(location)
+
+    expect(credentials.username).to be
+    expect(credentials.password).to be
+    expect(credentials.registry_endpoint).to match(/#{location}/)
+    expect(credentials.expires_at).to be > Time.now + 6 * 3600
+  end
+end

--- a/spec/docker_registry_credentials_spec.rb
+++ b/spec/docker_registry_credentials_spec.rb
@@ -11,6 +11,6 @@ describe 'as a user' do
     expect(credentials.username).to be
     expect(credentials.password).to be
     expect(credentials.registry_endpoint).to match(/#{location}/)
-    expect(credentials.expires_at).to be > Time.now + 6 * 3600
+    expect(credentials.expires_at).to be > (Time.now + 6 * 3600).to_i
   end
 end


### PR DESCRIPTION
This capability implements a subcommand in the EY core CLI which prints the docker login command to authorize the Docker Engine with the AWS ECR registry.