### PR TITLE
replacing legacy ssl_certificates endpoint with new ssl-certificates one

### DIFF
--- a/lib/ey-core/requests/get_ssl_certificate.rb
+++ b/lib/ey-core/requests/get_ssl_certificate.rb
@@ -5,7 +5,7 @@ class Ey::Core::Client
       url = params["url"]
 
       request(
-        :path => "ssl_certificates/#{id}",
+        :path => "ssl-certificates/#{id}",
         :url  => url,
       )
     end


### PR DESCRIPTION
This is to discontinue the use of legacy ssl_certificates endpoint and replace it with ssl-certificates one