### PR TITLE
NEW: adds name to server listing output

### DIFF
--- a/lib/ey-core/cli/servers.rb
+++ b/lib/ey-core/cli/servers.rb
@@ -32,7 +32,8 @@ module Ey
               { id: { width: 10 } },
               :role,
               :provisioned_id,
-              { public_hostname: { width: 50 } }
+              { public_hostname: { width: 50 } },
+              :name,
             ]
           ).table_print
         end


### PR DESCRIPTION
The old ey cli printed the name of the server, which is useful when you have tagged them with certain roles.