### PR TITLE
NEW: defaults servers per page to 100.

### DIFF
--- a/lib/ey-core/requests/get_servers.rb
+++ b/lib/ey-core/requests/get_servers.rb
@@ -1,6 +1,7 @@
 class Ey::Core::Client
   class Real
     def get_servers(params={})
+      params['per_page'] = ENV['CORE_SERVERS_PER_PAGE'] || 100
       request(
         :params => params,
         :query  => Ey::Core.paging_parameters(params),


### PR DESCRIPTION
A quick and dirty fix - if you have lots of servers, the pagination default of 20 wont cut the mustard.