### PR TITLE
Fixes no migrate

### DIFF
--- a/lib/ey-core/cli/deploy.rb
+++ b/lib/ey-core/cli/deploy.rb
@@ -93,12 +93,12 @@ EOF
           end
           if (option(:migrate) || switch_active?(:no_migrate))
             deploy_options.merge!(migrate_command: option(:migrate)) if option(:migrate)
-            deploy_options.merge!(migrate_command: '') if switch_active?(:no_migrate)
+            deploy_options.merge!(migrate_command: nil) if switch_active?(:no_migrate)
           else
             puts "missing migrate option (--migrate or --no-migrate), checking latest deploy...".yellow
             latest_deploy ||= environment.latest_deploy(app)
             if latest_deploy
-              deploy_options.merge!(migrate_command: (latest_deploy.migrate && latest_deploy.migrate_command) || '')
+              deploy_options.merge!(migrate_command: (latest_deploy.migrate && latest_deploy.migrate_command) || nil)
             else
               raise "either --migrate or --no-migrate needs to be specified"
             end


### PR DESCRIPTION
Sets migration command as `nil` rather than `''` because `''` still triggers a migration if set in ey.yml rather than overriding.

**Testing Done before Fix**

* Deployed normally without `--no-migrate ` or `--migrate` - Previous deploy command was used `with migration: "rake db:seed --trace".`.
* Deployed with `--migrate` command - command was used by the deploy `with migration: "rake db:migrate --trace".`
* Deploy with `--no-migrate` option  - migration was still triggerd output as `with migration: ''`
* Deployed with no migrate command by UI and then by CLI with no options. - CLI respected previous option which in this case was `without migration`


**Testing Done After Fix**

* Deployed normally without overriding `--no-migrate` or `--migrate` - Previous deploy command was used `with migration: "rake db:seed --trace".`.
* Deployed with `--no-migrate`  -  no migration command was sent out put was `without migration` 
* Deployed with no migrate command by UI and then by CLI with no options. - CLI respected previous option which in this case was `without migration`
* Deployed with `--migrate` command - command was used by the deploy `with migration: "rake db:migrate --trace".`

