### PR TITLE
EYPP-8535: Replace legacy `ssl_certificates` endpoint with new `ssl-c…

### DIFF
--- a/lib/ey-core/requests/get_ssl_certificate.rb
+++ b/lib/ey-core/requests/get_ssl_certificate.rb
@@ -5,7 +5,7 @@ class Ey::Core::Client
       url = params["url"]
 
       request(
-        :path => "ssl_certificates/#{id}",
+        :path => "ssl-certificates/#{id}",
         :url  => url,
       )
     end


### PR DESCRIPTION
https://jira.devfactory.com/browse/EYPP-8535

Fix: Replace legacy `ssl_certificates` endpoint with new `ssl-certificates` one.