### PR TITLE
[FBZ-9095] Update messaging from 'ey' to 'ey-core'

### DIFF
--- a/lib/ey-core/cli/deploy.rb
+++ b/lib/ey-core/cli/deploy.rb
@@ -63,7 +63,7 @@ module Ey
             abort <<-EOF
 Found account #{operator.name} but requested account #{option(:account)}.
 Use the ID of the account instead of the name.
-This can be retrieved by running "ey accounts".
+This can be retrieved by running "ey-core accounts".
 EOF
             .red unless operator.name == option(:account) || operator.id == option(:account)
           end

--- a/lib/ey-core/cli/helpers/chef.rb
+++ b/lib/ey-core/cli/helpers/chef.rb
@@ -28,7 +28,7 @@ module Ey
               puts "#{type.capitalize} chef run failed".red
               ap request
               if server = environment.servers.first
-                puts "For logs try `ey logs --server #{server.provisioned_id}` --environment #{environment.name}"
+                puts "For logs try `ey-core logs --server #{server.provisioned_id}` --environment #{environment.name}"
               end
             end
           end

--- a/lib/ey-core/cli/helpers/core.rb
+++ b/lib/ey-core/cli/helpers/core.rb
@@ -45,7 +45,7 @@ module Ey
 
           def core_operator_and_environment_for(options={})
             unless options[:environment]
-              raise "--environment is required (for a list of environments, try `ey environments`)"
+              raise "--environment is required (for a list of environments, try `ey-core environments`)"
             end
             operator = operator(options)
             environment = nil
@@ -61,7 +61,7 @@ module Ey
               end
             end
             unless environment
-              raise "environment '#{options[:environment]}' not found (for a list of environments, try `ey environments`)"
+              raise "environment '#{options[:environment]}' not found (for a list of environments, try `ey-core environments`)"
             end
             [operator, environment]
           end
@@ -131,7 +131,7 @@ module Ey
               write_core_yaml(legacy_token)
               retry
             elsif e.message.match(/missing token/i)
-              abort "Missing credentials: Run 'ey login' to retrieve your Engine Yard Cloud API token.".yellow
+              abort "Missing credentials: Run 'ey-core login' to retrieve your Engine Yard Cloud API token.".yellow
             else
               raise e
             end


### PR DESCRIPTION
Fix up a few remaining instance in output message to reference `ey-core` instead of `ey`