### PR TITLE
Removed the extra verbose block and added the way to pass the '-v' or  '--verbose' option to the command

### DIFF
--- a/lib/ey-core/cli/deploy.rb
+++ b/lib/ey-core/cli/deploy.rb
@@ -46,11 +46,6 @@ module Ey
         switch :verbose,
           short: "v",
           long: "verbose",
-          description: "Deploy with verbose output"
-
-        switch :verbose,
-          short: "v",
-          long: "verbose",
           description: "Stream deploy output to this console. Alias to stream for backwards compatibility."
 
         switch :no_migrate,
@@ -78,7 +73,7 @@ EOF
 
           app = core_application_for(environment, self.options)
 
-          deploy_options = {verbose: options[:verbose], cli_args: ARGV}
+          deploy_options = {verbose: switch_active?(:verbose), cli_args: ARGV}
           latest_deploy = nil
           if options[:ref]
             deploy_options.merge!(ref: option(:ref))


### PR DESCRIPTION
Removed the extra `verbose` option block and modified the way deploy checks for the verbose option. To test this I did the following:

* Started a container:
```
docker run --rm -ti ruby:2.5-slim-stretch /bin/bash
```

* In the container I ran:

```
root@6ea1f60f9b74:/# apt-get update && apt-get -y install curl gcc libxml2-dev libxslt-dev linux-headers-amd64 libcurl4-openssl-dev libpcre3-dev patch zlib1g-dev liblzma-dev build-essential nano

root@6ea1f60f9b74:/#  gem install 'ey-core'

root@6ea1f60f9b74:/# gem list ey-core

*** LOCAL GEMS ***

ey-core (3.6.1)
```

* Made the changes:

```
root@6ea1f60f9b74:/# nano /usr/local/bundle/gems/ey-core-3.6.1/lib/ey-core/cli/deploy.rb
```
* Invoked the deploy command to verify the results:

  - `ey-core deploy -c xxxxx  -e xxxxx -a xxxxx`   
  - `ey-core deploy -c xxxxx  -e xxxxx -a xxxxx -v`   
  - `ey-core deploy -c xxxxx  -e xxxxx  -a xxxxx  --verbose`