### PR TITLE
[FBZ-7928] add app master option for ssh to only run cmd on an env's app master

### DIFF
--- a/lib/ey-core/cli/helpers/server_sieve.rb
+++ b/lib/ey-core/cli/helpers/server_sieve.rb
@@ -6,6 +6,7 @@ module Ey
           ROLES = [
             :app_servers,
             :db_servers,
+            :app_master,
             :db_master,
             :utilities
           ]
@@ -55,6 +56,12 @@ module Ey
 
           def db_servers
             db_master + servers_api.all(role: 'db_slave').to_a
+          end
+          
+          def app_master
+            ['app_master', 'solo'].
+              map {|role| servers_api.all(role:role).to_a}.
+              flatten
           end
 
           def db_master

--- a/lib/ey-core/cli/ssh.rb
+++ b/lib/ey-core/cli/ssh.rb
@@ -54,6 +54,10 @@ module Ey
           long: "app_servers",
           description: "Run command on all application servers"
 
+	switch :app_master,
+	  long: "app_master",
+	  description: "Run command on app master"
+
         switch :db_servers,
           long: "db_servers",
           description: "Run command on all database servers"
@@ -97,6 +101,7 @@ module Ey
               environment.servers,
               all: switch_active?(:all),
               app_servers: switch_active?(:app_servers),
+              app_master: switch_active?(:app_master),
               db_servers: switch_active?(:db_servers),
               db_master: switch_active?(:db_master),
               utilities: option(:utilities)
@@ -113,6 +118,7 @@ module Ey
                 environment.servers,
                 all: switch_active?(:all),
                 app_servers: switch_active?(:app_servers),
+                app_master: switch_active?(:app_master),
                 db_servers: switch_active?(:db_servers),
                 db_master: switch_active?(:db_master),
                 utilities: option(:utilities)


### PR DESCRIPTION
The need to have an option to run ssh commands on only the app_master instance surfaced in ticket #177264 , this addresses that.