### PR TITLE
[FBZ-9094] Adds serverside version as argument

### DIFF
--- a/lib/ey-core/cli/deploy.rb
+++ b/lib/ey-core/cli/deploy.rb
@@ -35,7 +35,7 @@ module Ey
         option :serverside_version,
           short: "S",
           long: "serverside_version",
-          description: "The servside version must match our released gem.",
+          description: "Override the default version of engineyard-serverside. The version must match a released version. Use with care.",
           argument: "serverside_version"
 
         option :app,

--- a/lib/ey-core/cli/deploy.rb
+++ b/lib/ey-core/cli/deploy.rb
@@ -32,6 +32,11 @@ module Ey
           long: "migrate",
           description: "The migration command to run.  This option has a 50 character limit.",
           argument: "migrate"
+        option :serverside_version,
+          short: "S",
+          long: "serverside_version",
+          description: "The servside version must match our released gem.",
+          argument: "serverside_version"
 
         option :app,
           short: "a",
@@ -75,6 +80,9 @@ EOF
 
           deploy_options = {verbose: switch_active?(:verbose), cli_args: ARGV}
           latest_deploy = nil
+	  if options[:serverside_version]
+            deploy_options.merge!(serverside_version: option(:serverside_version))
+          end
           if options[:ref]
             deploy_options.merge!(ref: option(:ref))
           else

--- a/lib/ey-core/models/deployment.rb
+++ b/lib/ey-core/models/deployment.rb
@@ -9,6 +9,7 @@ class Ey::Core::Client::Deployment < Ey::Core::Model
   attribute :migrate_command
   attribute :ref
   attribute :resolved_ref
+  attribute :serverside_version
   attribute :started_at,     type: :time
   attribute :successful,     type: :boolean
   attribute :verbose

--- a/lib/ey-core/requests/deploy_environment_application.rb
+++ b/lib/ey-core/requests/deploy_environment_application.rb
@@ -30,6 +30,7 @@ class Ey::Core::Client
         "migrate_command" => options["deploy"]["migrate"] ? (options["deploy"]["migrate_command"] || "rake db:migrate") : nil,
         "migrate"         => options["deploy"]["migrate"] || false,
         "resolved_ref"    => options["deploy"]["ref"],
+        "serverside_version"    => options["deploy"]["serverside_version"],
         "started_at"      => Time.now,
         "successful"      => true
       }

--- a/lib/ey-core/version.rb
+++ b/lib/ey-core/version.rb
@@ -1,5 +1,5 @@
 module Ey
   module Core
-    VERSION = "3.6.1"
+    VERSION = "3.6.2"
   end
 end


### PR DESCRIPTION
Updates core-client to support serverside version.



**Testing Done After PR**

*  Deployed normally without `serverside_version` or `-S` to make sure the default serverside version was used.
* Deployed with `-S` option to make sure `serverside_version` stated was used.
* Deployed with `-S` option and non valid `serverside_version` to make sure deploy failed.

