### PR TITLE
fix(ssh): pass ssh options to the ssh command

### DIFF
--- a/lib/ey-core/cli/ssh.rb
+++ b/lib/ey-core/cli/ssh.rb
@@ -142,7 +142,7 @@ module Ey
             host = server.public_hostname
             name = server.name ? "#{server.role} (#{server.name})" : server.role
             puts "\nConnecting to #{name} #{host}".green
-            sshcmd = Escape.shell_command((ssh_cmd + ["#{user}@#{host}"] + [cmd]).compact)
+            sshcmd = Escape.shell_command((ssh_cmd + ssh_opts + ["#{user}@#{host}"] + [cmd]).compact)
             puts "Running command: #{sshcmd}".green
             system sshcmd
             exits << $?.exitstatus


### PR DESCRIPTION
Disclaimer: I don't know how to build this gem locally so I have not tested this change (shame on me, I know).

I've noticed that `--tty` option from `ssh` was not really working so I found out that the built `ssh_opts` are not appended to the `ssh` command.