### PR TITLE
GHI-4789 - Build the `cookiejar` gem from sources

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -5,6 +5,12 @@ gemspec
 
 gem "rack", "<= 2.1.4"
 
+# We build the cookiejar from sources because of the following reason.
+# The rubygems.org repository contains the latest cookiejar of the version 0.3.3. 
+# It is the latest published version. But the gem sources have several unpublished fixes.
+# One of them is about the support of the 'samesite' cookie which is used when we work with AWS ALB.
+gem "cookiejar", git: 'https://github.com/dwaite/cookiejar', branch: 'master'
+
 group :doc do
   gem 'yard'
   gem 'redcarpet'

--- a/lib/ey-core/version.rb
+++ b/lib/ey-core/version.rb
@@ -1,5 +1,5 @@
 module Ey
   module Core
-    VERSION = "3.6.4"
+    VERSION = "3.6.5"
   end
 end


### PR DESCRIPTION
The fix for https://github.com/trilogy-group/eng-maintenance/issues/4789.

The external gem `cookiejar` (which is referred from `faye`) of the latest published version 0.3.3 which is available on `rubygems.org` has not all fixes from the `master` banch, repo https://github.com/dwaite/cookiejar. We need one of them regarding the support of the `samesite` cookie. But the updates won't be published as the work on the gem has been suspended and the repo is archived now.
I reconfigured to get `cookiejar` not from the `rubygems.org` but from the source code. This has fixed the problem with `samesite` cookie.