### PR TITLE
Avoids undefined method error when parsing documentation

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rack", "<= 2.1.4"
 # The rubygems.org repository contains the latest cookiejar of the version 0.3.3. 
 # It is the latest published version. But the gem sources have several unpublished fixes.
 # One of them is about the support of the 'samesite' cookie which is used when we work with AWS ALB.
-gem "cookiejar", git: 'https://github.com/dwaite/cookiejar', branch: 'master'
+gem 'cookiejar', git: 'https://github.com/wzissel/cookiejar', branch: 'master'
 
 group :doc do
   gem 'yard'

--- a/Gemfile
+++ b/Gemfile
@@ -9,7 +9,7 @@ gem "rack", "<= 2.1.4"
 # The rubygems.org repository contains the latest cookiejar of the version 0.3.3. 
 # It is the latest published version. But the gem sources have several unpublished fixes.
 # One of them is about the support of the 'samesite' cookie which is used when we work with AWS ALB.
-gem 'cookiejar', git: 'https://github.com/wzissel/cookiejar', branch: 'master'
+gem "cookiejar", git: 'https://github.com/dwaite/cookiejar', branch: 'master'
 
 group :doc do
   gem 'yard'

--- a/lib/ey-core/cli/deploy.rb
+++ b/lib/ey-core/cli/deploy.rb
@@ -69,7 +69,7 @@ EOF
           end
 
           unless environment
-            abort "Unable to locate environment #{option[:environment]} in #{operator.name}".red
+            abort "Unable to locate environment #{options[:environment]} in #{operator.name}".red
           end
 
           unless option(:account)


### PR DESCRIPTION
Fix for issue https://github.com/engineyard/core-client-rb/issues/136

`option(:environment)` may have also been what was intended here, but `options[:environment]` seemed more likely to me with my unfamiliar grasp of the codebase.