### PR TITLE
GHI-5855 - Added the type field to the Ey::Core::Client::Alert class (updated ey-core 3.6.5)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,6 @@ tmp
 .rspec
 .gemrelease
 tags
+
+# Idea IDE files
+/.idea

--- a/.gitignore
+++ b/.gitignore
@@ -23,4 +23,4 @@ tmp
 tags
 
 # Idea IDE files
-/.idea
+.idea/

--- a/bin/console
+++ b/bin/console
@@ -1,0 +1,4 @@
+#!/usr/bin/env ruby
+
+require "irb"
+IRB.start(__FILE__)

--- a/ey-core.gemspec
+++ b/ey-core.gemspec
@@ -10,7 +10,7 @@ Gem::Specification.new do |gem|
   gem.email         = ["engineering@engineyard.com"]
   gem.description   = %q{Engine Yard Core API Ruby Client}
   gem.summary       = %q{Client library providing real and mock functionality for accessing Engine Yard's Core API}
-  gem.homepage      = ""
+  gem.homepage      = "https://github.com/engineyard/core-client-rb"
 
   gem.files         = `git ls-files`.split($/)
   gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }

--- a/lib/ey-core/models/alert.rb
+++ b/lib/ey-core/models/alert.rb
@@ -15,6 +15,7 @@ class Ey::Core::Client::Alert < Ey::Core::Model
   attribute :severity
   attribute :started_at, type: :time
   attribute :updated_at, type: :time
+  attribute :type
 
   attr_writer :database_server, :server, :agent, :resource
 

--- a/lib/ey-core/requests/get_alerts.rb
+++ b/lib/ey-core/requests/get_alerts.rb
@@ -2,7 +2,7 @@ class Ey::Core::Client
   class Real
     def get_alerts(params={})
 
-      puts "DEBUG - #{self.class}#get_alerts - Hey! I'm runngin"
+      puts "DEBUG - #{self.class}#get_alerts - Hey! I'm running"
 
       url   = params.delete("url")
       query = Ey::Core.paging_parameters(params)

--- a/lib/ey-core/requests/get_alerts.rb
+++ b/lib/ey-core/requests/get_alerts.rb
@@ -1,9 +1,6 @@
 class Ey::Core::Client
   class Real
     def get_alerts(params={})
-
-      puts "DEBUG - #{self.class}#get_alerts - Hey! I'm running"
-
       url   = params.delete("url")
       query = Ey::Core.paging_parameters(params)
 

--- a/lib/ey-core/requests/get_alerts.rb
+++ b/lib/ey-core/requests/get_alerts.rb
@@ -1,6 +1,9 @@
 class Ey::Core::Client
   class Real
     def get_alerts(params={})
+
+      puts "DEBUG - #{self.class}#get_alerts - Hey! I'm runngin"
+
       url   = params.delete("url")
       query = Ey::Core.paging_parameters(params)
 

--- a/lib/ey-core/version.rb
+++ b/lib/ey-core/version.rb
@@ -1,5 +1,5 @@
 module Ey
   module Core
-    VERSION = "3.6.5"
+    VERSION = "3.6.5.debug"
   end
 end

--- a/lib/ey-core/version.rb
+++ b/lib/ey-core/version.rb
@@ -1,5 +1,5 @@
 module Ey
   module Core
-    VERSION = "3.6.5.debug"
+    VERSION = "3.6.6"
   end
 end


### PR DESCRIPTION
The fix for https://github.com/trilogy-group/eng-maintenance/issues/5855.